### PR TITLE
update broken link and homebrew sha256

### DIFF
--- a/Formula/ratox.rb
+++ b/Formula/ratox.rb
@@ -1,14 +1,14 @@
 class Ratox < Formula
   homepage "http://ratox.2f30.org"
-  url "http://git.2f30.org/ratox/snapshot/ratox-0.2.1.tar.gz"
-  sha1 "de9efd61a5b21d992cc191e442a3468322fd94c0"
+  url "http://dl.2f30.org/releases/ratox-0.2.1.tar.gz"
+  sha256 "25ea4e7e286d23ca4fe99e0619c384fc6b371178e8877681b382d94dd958a9ba"
   head "git://git.2f30.org/ratox"
 
   depends_on "libtoxcore"
 
   patch do
     url "http://ratox.2f30.org/ratox-os_x.patch"
-    sha1 "71e0b0d4a3e40a74e80b781c19eca36589422273"
+    sha256 "903e6ce03c6a32bbcf88083b6a7d86172566adb88ef6a2996c7a61c3b0f605e7"
   end
 
   def install


### PR DESCRIPTION
When you try in homebrew to tap tox/tox you get the following error:

``` console
Error: Invalid formula: /usr/local/Homebrew/Library/Taps/tox/homebrew-tox/Formula/ratox.rb
Calling Formula.sha1 is disabled!
Use Formula.sha256 instead.
/usr/local/Homebrew/Library/Taps/tox/homebrew-tox/Formula/ratox.rb:4:in `<class:Ratox>'
Please report this to the tox/tox tap!
Error: Cannot tap tox/tox: invalid syntax in tap!
```

The download link for ratox is also broken.