### PR TITLE
Update repo urls, fix some deps

### DIFF
--- a/Formula/libtoxcore.rb
+++ b/Formula/libtoxcore.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Libtoxcore < Formula
-  head "git://github.com/irungentoo/toxcore", :using => :git
+  head "git://github.com/TokTok/c-toxcore", :using => :git
   homepage "https://tox.chat"
 
   depends_on "libsodium"

--- a/Formula/qtox.rb
+++ b/Formula/qtox.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Qtox < Formula
-  homepage "https://github.com/tux3/qTox"
-  head "git://github.com/tux3/qTox", :using => :git
+  homepage "https://github.com/qTox/qTox"
+  head "git://github.com/qTox/qTox", :using => :git
   
   depends_on "Tox/tox/libtoxcore"
   depends_on "qt5"
@@ -10,6 +10,7 @@ class Qtox < Formula
   depends_on "openal-soft"
   depends_on "Tox/tox/libfilteraudio"
   depends_on "qrencode"
+  depends_on "sqlcipher"
 
   def install
     mkdir "libs"

--- a/Formula/toxic.rb
+++ b/Formula/toxic.rb
@@ -5,7 +5,7 @@ class Toxic < Formula
   homepage "https://tox.chat"
 
   depends_on "libtoxcore"
-  depends_on "homebrew/dupes/ncurses"
+  depends_on "ncurses"
   depends_on "freealut"
   depends_on "libconfig"
   depends_on "qrencode"

--- a/Formula/utox.rb
+++ b/Formula/utox.rb
@@ -1,11 +1,12 @@
 require 'formula'
 
 class Utox < Formula
-  head "git://github.com/GrayHatter/uTox", :using => :git, :branch => "develop"
+  head "git://github.com/uTox/uTox", :using => :git, :branch => "develop"
   homepage "https://tox.chat"
 
-  depends_on "libtoxcore"
   depends_on "pkg-config" => :build
+  depends_on "cmake" => :build
+  depends_on "libtoxcore"
   depends_on "libfilteraudio"
 
   def install

--- a/Formula/utox.rb
+++ b/Formula/utox.rb
@@ -10,7 +10,10 @@ class Utox < Formula
   depends_on "libfilteraudio"
 
   def install
-    system "make", "-f", "src/cocoa/Makefile", "uTox.app"
-    prefix.install "uTox.app"
+    mkdir "build" do
+      system "cmake", "..", *std_cmake_args
+      system "make"
+      prefix.install "utox.app"
+    end
   end
 end


### PR DESCRIPTION
Includes the updated `libtoxcore` from #34 

`brew install qtox`
Works, but needed `depends_on "sqlcipher"`

`brew install toxic`
Works, but changed `depends_on "homebrew/dupes/ncurses"` to `depends_on "ncurses"` to satisfy a warning, `Warning: Use ncurses instead of deprecated homebrew/dupes/ncurses`

`brew install ratox`
This doesn't work, and I can't compile it manually either due to missing symbol `_NSIG` which appears to be some linux-specific `<signal.h>` value (OS X has `NSIG` in its `<signal.h>`).  It's not failing due to the updated `libtoxcore`.

`brew install utox`
This doesn't work, log:
```
» brew install --HEAD utox
==> Installing utox from tox/tox
==> Cloning git://github.com/uTox/uTox
Updating /Users/s/Library/Caches/Homebrew/utox--git
==> Checking out branch develop
==> make -f src/cocoa/Makefile uTox.app
Last 15 lines from /Users/s/Library/Logs/Homebrew/utox/01.make:
  "_switch_start_in_tray", referenced from:
      _config_load in settings.c.o
      _ui_rescale in ui.c.o
  "_switch_status_notifications", referenced from:
      _config_load in settings.c.o
      _ui_rescale in ui.c.o
  "_switch_typing_notes", referenced from:
      _config_load in settings.c.o
      _ui_rescale in ui.c.o
  "_switch_udp", referenced from:
      _config_load in settings.c.o
      _ui_rescale in ui.c.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [utox] Error 1

If reporting this issue please do so at (not Homebrew/brew or Homebrew/core):
https://github.com/tox/homebrew-tox/issues

These open issues may also help:
Tox install error / uTox https://github.com/Tox/homebrew-tox/issues/36
```

I am able to compile uTox manually using the instructions from https://github.com/uTox/uTox/blob/develop/docs/COCOA.md (which uses `cmake` instead of `make -f src/cocoa/Makefile uTox.app`), but the resulting binary crashes immediately with no diagnostics.  Unknown if related to `libtoxcore`.