### PR TITLE
Update libtoxcore.rb

### DIFF
--- a/Formula/libtoxcore.rb
+++ b/Formula/libtoxcore.rb
@@ -4,7 +4,7 @@ class Libtoxcore < Formula
   url "https://github.com/TokTok/c-toxcore.git",
     :tag => "v0.2.12",
     :revision => "9be4dbb4335bf7d893c8d00566d3276ab6dedd14"
-  head "git://github.com/TokTok/c-toxcore"
+  head "https://github.com/TokTok/c-toxcore"
 
   option "without-av", "Compile without A/V support"
   option "with-daemon", "Builds the bootstrap server daemon"


### PR DESCRIPTION
c.f. https://github.blog/2021-09-01-improving-git-protocol-security-github/

```
$ brew install --HEAD libtoxcore
[...]
Error: libtoxcore: Failed to download resource "libtoxcore"
Failure while executing; `git clone --branch master -c advice.detachedHead=false git://github.com/TokTok/c-toxcore /Users/admin/Library/Caches/Homebrew/libtoxcore--git` exited with 128. Here's the output:
Cloning into '/Users/admin/Library/Caches/Homebrew/libtoxcore--git'...
fatal: remote error:
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
```